### PR TITLE
fix: Eyes.__setitem__ writes the wrong eye and raises IndexError for key>=12

### DIFF
--- a/ovos_mark1/eyes/__init__.py
+++ b/ovos_mark1/eyes/__init__.py
@@ -224,7 +224,8 @@ class Eyes(list):
         assert 0 <= key <= 23
         if key < 12:
             self.left[key] = value
-        self.right[key] = value
+        else:
+            self.right[key - 12] = value
 
     def __iter__(self):
         for i in range(len(self)):


### PR DESCRIPTION
`__setitem__` runs `self.right[key] = value` unconditionally (no `else`), so `eyes[0]=px` writes *both* eyes; and for `key` in 12..23 it indexes `self.right` (12 pixels, 0..11) out of range → `IndexError` (e.g. `eyes[15]=px`). This mirrors the buggy half of `__getitem__`, which correctly does `self.right[item-12]`. Fix routes key<12 → left, key>=12 → `self.right[key-12]`. Found auditing for the Technical Manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)